### PR TITLE
ci: harden npm publish (OIDC Trusted Publishing + skip-when-published guard)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,45 +1,63 @@
 name: Publish to NPM
+
 on:
   push:
     branches: [master]
   release:
     types: [published]
+  workflow_dispatch:
+
+# Serialize publish runs so two never race to publish the same version.
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
 
 permissions:
   contents: read
+  id-token: write # required for npm Trusted Publishing (OIDC) and provenance
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24' # npm >= 11.5.1 (bundled) is required for Trusted Publishing
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
-      - name: Build
-        run: npm run build
-      - name: Test
-        run: npm test
-      - name: Check whether this version is already published
-        id: version_check
+          # npm caching is intentionally left off: on a publishing job a poisoned
+          # cache could leak the short-lived OIDC credentials to third-party code.
+
+      - name: Determine whether this version needs publishing
+        id: check
         run: |
           NAME=$(node -p "require('./package.json').name")
           VERSION=$(node -p "require('./package.json').version")
-          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
-            echo "$NAME@$VERSION is already published; skipping publish."
-            echo "exists=true" >> "$GITHUB_OUTPUT"
+          PUBLISHED=$(npm view "$NAME@$VERSION" version 2>/dev/null || true)
+          if [ "$PUBLISHED" = "$VERSION" ]; then
+            echo "$NAME@$VERSION is already published; nothing to do."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
           else
-            echo "$NAME@$VERSION is not yet published; will publish."
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "$NAME@$VERSION is not published yet; will build, test, and publish."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Publish package on NPM
-        if: steps.version_check.outputs.exists == 'false'
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+      - name: Install dependencies
+        if: steps.check.outputs.publish == 'true'
+        run: npm ci
+
+      - name: Build
+        if: steps.check.outputs.publish == 'true'
+        run: npm run build
+
+      - name: Test
+        if: steps.check.outputs.publish == 'true'
+        run: npm test
+
+      - name: Publish to npm
+        if: steps.check.outputs.publish == 'true'
+        run: npm publish --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,7 +26,20 @@ jobs:
         run: npm run build
       - name: Test
         run: npm test
+      - name: Check whether this version is already published
+        id: version_check
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "$NAME@$VERSION is already published; skipping publish."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "$NAME@$VERSION is not yet published; will publish."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish package on NPM
+        if: steps.version_check.outputs.exists == 'false'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/neotan/jest-snapshot-delete-properties"
+    "url": "git+https://github.com/neotan/jest-snapshot-delete-properties.git"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",


### PR DESCRIPTION
## Problem

The `Publish to NPM` workflow ran `npm publish` on every push to master without bumping the version, so it failed once a version was published. The [failed run](https://github.com/neotan/jest-snapshot-delete-properties/actions/runs/31071674101) errored with `404 ... 'jest-snapshot-delete-properties@1.0.0' is not in this registry`, which for an existing package indicates the long-lived `NPM_PUBLISH_TOKEN` is invalid/expired.

## Changes

- **Trusted Publishing (OIDC).** Replace the long-lived `NODE_AUTH_TOKEN` with npm OIDC (`id-token: write`). No secret to expire or leak, and provenance is attached automatically.
- **Skip when already published.** Query the registry for the current `package.json` version first and skip build/test/publish entirely when it already exists, so no-op master pushes pass fast instead of failing.
- **Current actions / runtime.** `actions/checkout@v7`, `actions/setup-node@v7`, Node 24 (npm >= 11.5.1, required by Trusted Publishing). Clears the Node 20 deprecation warning.
- **Reliability.** `concurrency` group serializes publish runs, a 10-minute `timeout-minutes`, and `workflow_dispatch` for manual publishes.
- **Security.** npm dependency caching is left off on the publish job to avoid exposing OIDC credentials via a poisoned cache.
- Normalized `repository.url` to silence the `npm pkg fix` warning.

## Required one-time setup (on npmjs.com)

Trusted Publishing needs a Trusted Publisher configured for the package: on the npm package settings, add a GitHub Actions publisher pointing at `neotan/jest-snapshot-delete-properties`, workflow `.github/workflows/npm-publish.yml`. Until that's configured, an actual version-bump publish will fail (ordinary pushes still pass because they skip publishing). No repo secret is needed anymore; the old `NPM_PUBLISH_TOKEN` can be deleted.